### PR TITLE
Enabling skipped tests

### DIFF
--- a/flyingpigeon/tests/test_indices.py
+++ b/flyingpigeon/tests/test_indices.py
@@ -18,7 +18,6 @@ def test_indices_description():
     assert 'TG: ' in indices.indices_description()
 
 
-# @pytest.mark.skip(reason="no way of currently testing this")
 def test_indice_simple():
     # SU expects tasmax
     resources = [local_path(TESTDATA['cordex_tasmax_2006_nc'])]
@@ -35,18 +34,15 @@ def test_indice_simple():
     assert len(ds.variables['time']) == 1
 
 
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_indice_percentile():
     # TX90p expects tasmax
     resources = [local_path(TESTDATA['cordex_tasmax_2006_nc'])]
     output = indices.calc_indice_percentile(
         resources, variable='tasmax',
-        indices=['TX'], percentile=90, groupings='year',
+        indices=['TX'], percentile=90, grouping='year',
         dir_output=tempfile.mkdtemp())
 
-    assert os.path.basename(output[0]) == 'TX_EUR-44_MPI-M-MPI-ESM-LR_rcp45_r1i1p1_MPI-CSC-REMO2009_v1_mon_200602-200612.nc'  # noqa
-
-    ds = Dataset(output[0])
+    ds = Dataset(output)
     # SU variable must be in result
     assert 'TX' in ds.variables
     # 1 year

--- a/flyingpigeon/tests/test_indices.py
+++ b/flyingpigeon/tests/test_indices.py
@@ -33,7 +33,7 @@ def test_indice_simple():
         # 1 year
         assert len(ds.variables['time']) == 1
 
-
+@pytest.mark.skip
 def test_indice_percentile():
     # TX90p expects tasmax
     resources = [local_path(TESTDATA['cordex_tasmax_2006_nc'])]
@@ -42,8 +42,8 @@ def test_indice_percentile():
         indices=['TX'], percentile=90, grouping='yr',
         dir_output=tempfile.mkdtemp())
 
-    #assert os.path.basename(output[
-    #                            0]) == 'SU_EUR-44_MPI-M-MPI-ESM-LR_rcp45_r1i1p1_MPI-CSC-REMO2009_v1_mon_200602-200612.nc'  # noqa
+    assert os.path.basename(output[
+                                0]) == 'SU_EUR-44_MPI-M-MPI-ESM-LR_rcp45_r1i1p1_MPI-CSC-REMO2009_v1_mon_200602-200612.nc'  # noqa
     with Dataset(output) as ds:
         # SU variable must be in result
         assert 'TX' in ds.variables

--- a/flyingpigeon/tests/test_indices.py
+++ b/flyingpigeon/tests/test_indices.py
@@ -27,11 +27,11 @@ def test_indice_simple():
 
     assert os.path.basename(output[0]) == 'SU_EUR-44_MPI-M-MPI-ESM-LR_rcp45_r1i1p1_MPI-CSC-REMO2009_v1_mon_200602-200612.nc'  # noqa
 
-    ds = Dataset(output[0])
-    # SU variable must be in result
-    assert 'SU' in ds.variables
-    # 1 year
-    assert len(ds.variables['time']) == 1
+    with Dataset(output[0]) as ds:
+        # SU variable must be in result
+        assert 'SU' in ds.variables
+        # 1 year
+        assert len(ds.variables['time']) == 1
 
 
 def test_indice_percentile():
@@ -39,11 +39,13 @@ def test_indice_percentile():
     resources = [local_path(TESTDATA['cordex_tasmax_2006_nc'])]
     output = indices.calc_indice_percentile(
         resources, variable='tasmax',
-        indices=['TX'], percentile=90, grouping='year',
+        indices=['TX'], percentile=90, grouping='yr',
         dir_output=tempfile.mkdtemp())
 
-    ds = Dataset(output)
-    # SU variable must be in result
-    assert 'TX' in ds.variables
-    # 1 year
-    assert len(ds.variables['time']) == 1
+    #assert os.path.basename(output[
+    #                            0]) == 'SU_EUR-44_MPI-M-MPI-ESM-LR_rcp45_r1i1p1_MPI-CSC-REMO2009_v1_mon_200602-200612.nc'  # noqa
+    with Dataset(output) as ds:
+        # SU variable must be in result
+        assert 'TX' in ds.variables
+        # 1 year
+        assert len(ds.variables['time']) == 1

--- a/flyingpigeon/tests/test_wps_analogs_detection.py
+++ b/flyingpigeon/tests/test_wps_analogs_detection.py
@@ -3,14 +3,14 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for
+from .common import client_for, CFG_FILE
 from flyingpigeon.processes import processes
 
 
 @pytest.mark.online
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_wps_analogs_detection():
-    client = client_for(Service(processes=[]))
+    client = client_for(Service(processes=[], cfgfiles=CFG_FILE))
     datainputs = "dateSt=2013-07-15;dateEn=2013-12-31;refSt=2013-01-01;refEn=2013-12-31"
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',

--- a/flyingpigeon/tests/test_wps_c4i_simple_indice.py
+++ b/flyingpigeon/tests/test_wps_c4i_simple_indice.py
@@ -3,12 +3,12 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import TESTDATA, client_for, CFG_FILE
 
 
 @pytest.mark.skip(reason="no way of currently testing this")
 def test_wps_c4i_simple_indice():
-    client = client_for(Service(processes=[]))
+    client = client_for(Service(processes=[], cfgfiles=CFG_FILE))
     datainputs = "files@xlink:href={0};indiceName=SU;varName=tasmax".format(TESTDATA['cmip5_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',

--- a/flyingpigeon/tests/test_wps_fetch.py
+++ b/flyingpigeon/tests/test_wps_fetch.py
@@ -3,11 +3,11 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import TESTDATA, client_for, CFG_FILE
 from flyingpigeon.processes import FetchProcess
 
 def test_wps_fetch():
-    client = client_for(Service(processes=[FetchProcess()]))
+    client = client_for(Service(processes=[FetchProcess()], cfgfiles=CFG_FILE))
     datainputs = "resource=files@xlink:href={0}".format(TESTDATA['cmip5_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',

--- a/flyingpigeon/tests/test_wps_fetch.py
+++ b/flyingpigeon/tests/test_wps_fetch.py
@@ -6,14 +6,11 @@ from pywps.tests import assert_response_success
 from .common import TESTDATA, client_for
 from flyingpigeon.processes import FetchProcess
 
-
-@pytest.mark.online
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_wps_fetch():
     client = client_for(Service(processes=[FetchProcess()]))
-    datainputs = "resource@xlink:href={0}".format(TESTDATA['cmip5_tasmax_2006_nc'])
+    datainputs = "resource=files@xlink:href={0}".format(TESTDATA['cmip5_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',
-        identifier='fetch',
+        identifier='fetch_resources',
         datainputs=datainputs)
     assert_response_success(resp)

--- a/flyingpigeon/tests/test_wps_indices_percentile.py
+++ b/flyingpigeon/tests/test_wps_indices_percentile.py
@@ -7,10 +7,10 @@ from .common import TESTDATA, client_for
 from flyingpigeon.processes import IndicespercentiledaysProcess
 
 
-@pytest.mark.skip(reason="ocgis fails in this test")
 def test_wps_indices_percentiledays():
     client = client_for(Service(processes=[IndicespercentiledaysProcess()]))
-    datainputs = "resource@xlink:href={0};percentile=90".format(TESTDATA['cordex_tasmax_2006_nc'])
+    datainputs = "resource=files@xlink:href={0};percentile=90"\
+        .format(TESTDATA['cordex_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',
         identifier='indices_percentiledays',

--- a/flyingpigeon/tests/test_wps_indices_percentile.py
+++ b/flyingpigeon/tests/test_wps_indices_percentile.py
@@ -3,12 +3,12 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import TESTDATA, client_for, CFG_FILE
 from flyingpigeon.processes import IndicespercentiledaysProcess
 
 
 def test_wps_indices_percentiledays():
-    client = client_for(Service(processes=[IndicespercentiledaysProcess()]))
+    client = client_for(Service(processes=[IndicespercentiledaysProcess()], cfgfiles=CFG_FILE))
     datainputs = "resource=files@xlink:href={0};percentile=90"\
         .format(TESTDATA['cordex_tasmax_2006_nc'])
     resp = client.get(

--- a/flyingpigeon/tests/test_wps_indices_simple.py
+++ b/flyingpigeon/tests/test_wps_indices_simple.py
@@ -3,12 +3,12 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import TESTDATA, client_for, CFG_FILE
 from flyingpigeon.processes import IndicessingleProcess
 
 
 def test_wps_indices_simple():
-    client = client_for(Service(processes=[IndicessingleProcess()]))
+    client = client_for(Service(processes=[IndicessingleProcess()], cfgfiles=CFG_FILE))
     datainputs = "resource=files@xlink:href={0};indices=SU;grouping=yr".\
         format(TESTDATA['cordex_tasmax_2006_nc'])
     resp = client.get(

--- a/flyingpigeon/tests/test_wps_indices_simple.py
+++ b/flyingpigeon/tests/test_wps_indices_simple.py
@@ -7,12 +7,12 @@ from .common import TESTDATA, client_for
 from flyingpigeon.processes import IndicessingleProcess
 
 
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_wps_indices_simple():
     client = client_for(Service(processes=[IndicessingleProcess()]))
-    datainputs = "resource@xlink:href={0};indices=SU".format(TESTDATA['cordex_tasmax_2006_nc'])
+    datainputs = "resource=files@xlink:href={0};indices=SU;grouping=yr".\
+        format(TESTDATA['cordex_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',
-        identifier='indices_simple',
+        identifier='indices_single',
         datainputs=datainputs)
     assert_response_success(resp)

--- a/flyingpigeon/tests/test_wps_plot_timeseries.py
+++ b/flyingpigeon/tests/test_wps_plot_timeseries.py
@@ -6,12 +6,10 @@ from pywps.tests import assert_response_success
 from .common import TESTDATA, client_for
 from flyingpigeon.processes import PlottimeseriesProcess
 
-
-@pytest.mark.online
-@pytest.mark.skip(reason="no way of currently testing this")
+@pytest.mark.slow
 def test_wps_plot_timeseries():
     client = client_for(Service(processes=[PlottimeseriesProcess()]))
-    datainputs = "resource@xlink:href={0};variable=tasmax".format(TESTDATA['cmip5_tasmax_2006_nc'])
+    datainputs = "resource=files@xlink:href={0};variable=tasmax".format(TESTDATA['cmip5_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',
         identifier='plot_timeseries',

--- a/flyingpigeon/tests/test_wps_plot_timeseries.py
+++ b/flyingpigeon/tests/test_wps_plot_timeseries.py
@@ -3,12 +3,12 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import TESTDATA, client_for, CFG_FILE
 from flyingpigeon.processes import PlottimeseriesProcess
 
 @pytest.mark.slow
 def test_wps_plot_timeseries():
-    client = client_for(Service(processes=[PlottimeseriesProcess()]))
+    client = client_for(Service(processes=[PlottimeseriesProcess()], cfgfiles=CFG_FILE))
     datainputs = "resource=files@xlink:href={0};variable=tasmax".format(TESTDATA['cmip5_tasmax_2006_nc'])
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',

--- a/flyingpigeon/tests/test_wps_sdm_gbiffetch.py
+++ b/flyingpigeon/tests/test_wps_sdm_gbiffetch.py
@@ -3,15 +3,15 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import TESTDATA, client_for
+from .common import client_for
 from flyingpigeon.processes import GBIFfetchProcess
 
-
+@pytest.mark.skip # This is much too long. I suggest we create a test that requires less data to be downloaded.
+@pytest.mark.slow
 @pytest.mark.online
-@pytest.mark.skip(reason="no way of currently testing this")
 def test_wps_sdm_gbiffetch():
     client = client_for(Service(processes=[GBIFfetchProcess()]))
-    datainputs = "taxon_name=Fagus sylvatica;BBox=-10,20,10,40;"
+    datainputs = "taxon_name=Fagus sylvatica;BBox=-10,20,10,40;" # BBox is not supported in the process.
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',
         identifier='sdm_gbiffetch',

--- a/flyingpigeon/tests/test_wps_sdm_gbiffetch.py
+++ b/flyingpigeon/tests/test_wps_sdm_gbiffetch.py
@@ -3,14 +3,14 @@ import pytest
 from pywps import Service
 from pywps.tests import assert_response_success
 
-from .common import client_for
+from .common import client_for, CFG_FILE
 from flyingpigeon.processes import GBIFfetchProcess
 
 @pytest.mark.skip # This is much too long. I suggest we create a test that requires less data to be downloaded.
 @pytest.mark.slow
 @pytest.mark.online
 def test_wps_sdm_gbiffetch():
-    client = client_for(Service(processes=[GBIFfetchProcess()]))
+    client = client_for(Service(processes=[GBIFfetchProcess()], cfgfiles=CFG_FILE))
     datainputs = "taxon_name=Fagus sylvatica;BBox=-10,20,10,40;" # BBox is not supported in the process.
     resp = client.get(
         service='WPS', request='Execute', version='1.0.0',


### PR DESCRIPTION
I went through the tests that were skipped and re-activated those that I could fix. 

The sdm_gbiffetch test is too slow to run. Solution would be to enable BBox or limit. 