### PR TITLE
Review of README and documentation index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,28 +17,18 @@ Flyingpigeon
     :target: https://gitter.im/bird-house/birdhouse?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
     :alt: Join the chat at https://gitter.im/bird-house/birdhouse
 
-|
-|
 
-Flying Pigeon (the bike)
-  *Flying Pigeon is a Chinese bicycle company [..]. The Flying Pigeon is the most popular vehicle ever.* ( `Wikipedia <https://en.wikipedia.org/wiki/Flying_Pigeon>`_ )
+A Web Processing Service Testbed
+--------------------------------
 
-Flying Pigeon (the bird)
-  *The pigeon finds its way home over extremely long distances. [..].* ( `Wikipedia <https://en.wikipedia.org/wiki/Pigeon_flying>`_ ).
+Flyingpigeon is a server providing a sandbox and test environment for new Web Processing Services (OGC WPS). It is part of the `birdhouse`_ ecosystem, which aims to build interoperable services in support to substainable development goals. Once stable, mature and thoroughly tested, Flyingpigeon services are meant to move to stand-alone thematic servers used in production.
 
-A Web Processing Service - Testbed for new process development.
----------------------------------------------------------------
+The Flyingpigeon software stack as of version 1.0 was published in `Computers & Geosciences <https://www.sciencedirect.com/science/article/pii/S0098300416302801>`_ and can still be accessed from the `release page <https://github.com/bird-house/flyingpigeon/releases/tag/1.0.0>`_. Meanwhile many of the 1.0 processes have migrated to other birdhouse repositories. For example, processes related to extreme weather event assessment can be found in `blackswan`_, while processes focusing on climate indices will be found in `finch`_.
 
-Flyingpigeon is OGC based Web Processing Service and in line with the birdhouse development.
-It was released as Version 1.0 and `published accordingly in the Computers & Geosciences <https://www.sciencedirect.com/science/article/pii/S0098300416302801>`_
-
-Meanwhile birdhouse has change a lot and also the flyingpigeon WPS. Most of the processes are migrated to other birds (WPS services) in birdhouse.
-Processes related to extreme weather event assessment can be found in blackswan, Processes focusing on Climate indices will be found in finch.
-
-Flyingpigeon is one of the early birds of birdhouse and is currently seen as Testbed for new process development.
-Recently, eggshell was introduced to birdhouse which is containing most of the common functions. Flyingpigeon is calling eggshell as one of the main compartment.
-
-* Free software: Apache Software License 2.0
-* Documentation: https://flyingpigeon.readthedocs.io.
+* Documentation: https://flyingpigeon.readthedocs.io
 * GitHub repository: https://github.com/bird-house/flyingpigeon
-* Birdhouse Overview: https://flyingpigeon.readthedocs.io/en/latest/
+* Birdhouse overview: https://birdhouse.readthedocs.io/en/latest/
+
+.. _blackswan: https://github.com/bird-house/blackswan
+.. _birdhouse: https://birdhouse.readthedocs.io/en/latest/
+.. _finch: https://github.com/bird-house/finch

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,9 @@
 .. include:: ../../README.rst
 
+Table of content
+----------------
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
 
    installation
    configuration
@@ -13,8 +14,19 @@
    changes
    authors
 
+
 Indices and tables
-==================
+------------------
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+
+----
+
+
+Flying Pigeon (the bike)
+  *Flying Pigeon is a Chinese bicycle company [..]. The Flying Pigeon is the most popular vehicle ever.* ( `Wikipedia <https://en.wikipedia.org/wiki/Flying_Pigeon>`_ )
+
+Flying Pigeon (the bird)
+  *The pigeon finds its way home over extremely long distances. [..].* ( `Wikipedia <https://en.wikipedia.org/wiki/Pigeon_flying>`_ ).


### PR DESCRIPTION
There were a couple of typos in the README, so I took the opportunity to review the text. In particular, I moved the wikipedia entries in the index.rst, so it shows up at the bottom of the page. I thought it was distracting to have the bird wikipedia entries at the very top. 

