### PR TITLE
conda env: add psycopg2 and remove birdhouse channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: flyingpigeon
 channels:
-- birdhouse
 - conda-forge
 - defaults
 dependencies:
@@ -10,6 +9,7 @@ dependencies:
 - jinja2
 - click
 - psutil
+- psycopg2
 # - eggshell
 ##############
 # analytic


### PR DESCRIPTION
"psycopg2" is to fix the following error:
```
2019-10-24 19:10:04,943] [ERROR] line=45 module=exceptions Exception: code: 500, description: No applicable error code, please check error log., locator:
Traceback (most recent call last):
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/pywps/app/Service.py", line 314, in call
    log_request(request_uuid, wps_request)
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/pywps/dblog.py", line 71, in log_request
    session = get_session()
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/pywps/dblog.py", line 175, in get_session
    engine = sqlalchemy.create_engine(database, echo=echo, poolclass=NullPool)
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/sqlalchemy/engine/__init__.py", line 479, in create_engine
    return strategy.create(*args, **kwargs)
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/sqlalchemy/engine/strategies.py", line 87, in create
    dbapi = dialect_cls.dbapi(**dbapi_args)
  File "/opt/conda/envs/wps/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 737, in dbapi
    import psycopg2
ModuleNotFoundError: No module named 'psycopg2'
```
When the following config is used when running the docker image:
```
[logging]
level = INFO
database=postgresql://user:pass@postgres/flyingpigeon
```
"psycopg2" technically is only needed for production deployment so
potentially be added via individual `conda install` inside `Dockerfile`
instead.  I choose to add it to `environment.yml` so that during
dev/testing, we can also replicate "production environment".

It's always a best practice that dev/test environment mirror as much as
possible the production environment to smoke out all the relevant bugs.

"birdhouse" channel is removed because supposedly none of the packages need to
come from birdhouse anymore.

Leaving birdhouse channel in place might inadvertently use older releases from
birdhouse and overshadow the good one.

## Additional Information

No more ModuleNotFoundError error in logs but unable to use existing notebook to test since FP is also affected by this bug: https://github.com/geopython/pywps/pull/499
