### PR TITLE
Update pywps to 4.2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python=3
 - pip
-- pywps=4.2.2
+- pywps=4.2.3
 - jinja2
 - click
 - psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywps>=4.2.0
+pywps>=4.2.3
 jinja2
 click
 psutil

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,0 +1,15 @@
+from pywps import Service
+from .common import client_for
+from flyingpigeon.processes import processes
+from owslib.wps import WebProcessingService
+
+
+def test_describe():
+    """Check that owslib can parse the processes' description."""
+    # Get the description of all processes
+    client = client_for(Service(processes=processes))
+    resp = client.get(service='wps', request='describeprocess', identifier='all', version='1.0.0')
+
+    # Parse the description with owslib. Dummy URL.
+    wps = WebProcessingService("http://localhost", skip_caps=True)
+    wps.describeprocess("all", xml=resp.data)


### PR DESCRIPTION
## Overview

This PR fixes an issue where OWSlib cannot parse the describe process output due to an empty DefaultValue field for literal inputs. 

