### PR TITLE
Refresh cookiecutter and undo pywps source pin

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
     "template": "https://github.com/bird-house/cookiecutter-birdhouse.git",
-    "commit": "4eac1f5443b249e80971d9ead1d6b3a98f07569b",
+    "commit": "f157ea8419fd4e32a9e4d52e613c90c807190e7e",
     "skip": [
         "flyingpigeon/processes/wps_say_hello.py",
         "tests/test_wps_hello.py",

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /opt/wps
 RUN ["conda", "env", "create", "-n", "wps", "-f", "environment.yml"]
 
 # Install WPS
-RUN ["/bin/bash", "-c", "source activate wps && python setup.py install"]
+RUN ["/bin/bash", "-c", "source activate wps && pip install -e ."]
 
 # Start WPS service on port 8093 on 0.0.0.0
 EXPOSE 8093

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ develop:
 	@echo "Installing development requirements for tests and docs ..."
 	@-bash -c 'pip install -e ".[dev]"'
 	@-bash -c 'pip install git+https://github.com/metalink-dev/pymetalink@v6.2#egg=pymetalink --upgrade'
-	@-bash -c 'pip install git+https://github.com/Ouranosinc/pywps@2a55b6e95f51c648dc94bf3c89db7370b56c1c9c#egg=pywps --upgrade'
 
 
 .PHONY: start

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -5,8 +5,7 @@ channels:
 - defaults
 dependencies:
 - python=3.7
-# restore once an official pywps release contain the fix
-#- pywps>=4.2.4
+- pywps>=4.2.7
 - sphinx
 - nbsphinx
 - ipython
@@ -15,5 +14,3 @@ dependencies:
 - pip:
   - https://github.com/metalink-dev/pymetalink/archive/master.zip
   - sphinx_rtd_theme
-  # delete once an official pywps release contain this fix, also delete in Makefile
-  - https://github.com/Ouranosinc/pywps/archive/2a55b6e95f51c648dc94bf3c89db7370b56c1c9c.zip

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python=3
 - pip
-- pywps=4.2.3
+- pywps>=4.2.7
 - jinja2
 - click
 - psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywps>=4.2.3
+pywps>=4.2.7
 jinja2
 click
 psutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,10 @@
-pytest
+pytest>=6.0
 flake8
 pytest-flake8
 ipython
 pytest-notebook
 nbsphinx
-nbval
+nbval>=0.9.6
 nbconvert
 sphinx>=1.7
 bumpversion


### PR DESCRIPTION
This PR undo the pywps source pinning needed to build documentation in the previous PR https://github.com/bird-house/flyingpigeon/pull/336 and https://github.com/bird-house/cookiecutter-birdhouse/pull/96.

Note in `environment.yml` I also use `>=` instead of just `=`.  `requirements.txt` already using `>=` so not sure why not in `environment.yml`.

RtD test build https://flyingpigeon.readthedocs.io/en/test-rtd-build/ and matching build logs https://readthedocs.org/api/v2/build/11602765.txt (commit 0585962cd39ee4d7969af774723cb205c05d6c33).

