### PR TITLE
Use POST to filter features from WFS server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ develop:
 	@-bash -c 'pip install -e ".[dev]"'
 	@-bash -c 'pip install git+https://github.com/metalink-dev/pymetalink@v6.2#egg=pymetalink --upgrade'
 
+	# Remove once PR https://github.com/geopython/OWSLib/pull/706 is merged
+	# and a new release of OWSLib containing the feature is available.
+	# To keep this change before official OWSLib release, lock down the
+	# exact commit hash id instead of the branch name 'wfs-getfeature-post'.
+	@-bash -c 'pip install git+https://github.com/f-PLT/OWSLib@wfs-getfeature-post#egg=owslib --upgrade'
+
 
 .PHONY: start
 start:

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,6 @@ develop:
 	@-bash -c 'pip install -e ".[dev]"'
 	@-bash -c 'pip install git+https://github.com/metalink-dev/pymetalink@v6.2#egg=pymetalink --upgrade'
 
-	# Remove once PR https://github.com/geopython/OWSLib/pull/706 is merged
-	# and a new release of OWSLib containing the feature is available.
-	# To keep this change before official OWSLib release, lock down the
-	# exact commit hash id instead of the branch name 'wfs-getfeature-post'.
-	@-bash -c 'pip install git+https://github.com/f-PLT/OWSLib@wfs-getfeature-post#egg=owslib --upgrade'
-
-
 .PHONY: start
 start:
 	@echo "Starting application ..."

--- a/flyingpigeon/subset_base.py
+++ b/flyingpigeon/subset_base.py
@@ -14,7 +14,8 @@ def get_feature(url, typename, features):
     """Return geometry from WFS server."""
     wfs = WebFeatureService(url, version='2.0.0')
     resp = wfs.getfeature([typename], featureid=features,
-                          outputFormat='application/json')
+                          outputFormat='application/json',
+                          method="Post")
     return json.loads(resp.read())
 
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1,0 +1,11 @@
+from flyingpigeon.subset_base import get_feature
+
+def test_get_feature():
+    url = "https://pavics.ouranos.ca/geoserver/wfs"
+    typename = "public:USGS_HydroBASINS_lake_na_lev12"
+    feature_pat = "USGS_HydroBASINS_lake_na_lev12.{}"
+
+    #features = [feature_pat.format(i) for i in range(67088, 67449)]
+    features = [feature_pat.format(i) for i in range(67088, 67090)]
+    get_feature(url, typename, features)
+


### PR DESCRIPTION
## Overview

This PR fixes #290

Changes:

* Use POST in `wfs.getfeature`

## Related Issue / Discussion
#290

## Additional Information
Wait for OWSLib release to merge PR. 

